### PR TITLE
Change React.__spread to Object.assign

### DIFF
--- a/react-internal-nav.js
+++ b/react-internal-nav.js
@@ -28,7 +28,7 @@ module.exports = React.createClass({
   },
 
   render: function () {
-    return React.createElement(this.props.tagType, React.__spread({onClick: this.onPotentialNav}, this.props),
+    return React.createElement(this.props.tagType, Object.assign({onClick: this.onPotentialNav}, this.props),
       this.props.children
     )
   }


### PR DESCRIPTION
React.__spread is now deprecated in React 15 and will eventually be removed. This closes #1.
